### PR TITLE
[RFR] Fix typings index file name in filesGlob

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     ],
     "filesGlob": [
         "src/*.ts",
-        "typings/main.d.ts",
+        "typings/index.d.ts",
         "custom_typings/main.d.ts",
         "!node_modules/**"
     ],


### PR DESCRIPTION
Fix typings index file name in filesGlob (typings v1.0)